### PR TITLE
Deployment/release improvements

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ import (
 type spec struct {
 	Bind       string `envconfig:"DRONE_BIND"`
 	Debug      bool   `envconfig:"DRONE_DEBUG"`
-	Secret     string `envconfig:"DRONE_SECRET"`
+	Secret     string `envconfig:"DRONE_VALIDATE_PLUGIN_SECRET"`
 	PolicyPath string `envconfig:"DRONE_POLICY_PATH"`
 }
 

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -20,7 +20,9 @@ import (
 func New(policy string) validator.Plugin {
 	log.SetFormatter(&log.JSONFormatter{})
 	log.SetOutput(os.Stdout)
-
+	if policy == "" {
+		policy = "../policy"
+	}
 	return &plugin{
 		policyPath: policy,
 	}

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -21,7 +21,7 @@ func New(policy string) validator.Plugin {
 	log.SetFormatter(&log.JSONFormatter{})
 	log.SetOutput(os.Stdout)
 	if policy == "" {
-		policy = "../policy"
+		policy = "./policy"
 	}
 	return &plugin{
 		policyPath: policy,

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -61,7 +61,7 @@ func checkOutput(plugin validator.Plugin, sampleFile, expected string) func(*tes
 }
 
 func TestPlugin(t *testing.T) {
-	plugin := New("../policy/validation.rego")
+	plugin := New("")
 	pipeline, err := getSamplePipeline("authorized-type.yml")
 	if err != nil {
 		t.Error(err)

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"io/ioutil"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/drone/drone-go/drone"
@@ -61,7 +62,7 @@ func checkOutput(plugin validator.Plugin, sampleFile, expected string) func(*tes
 }
 
 func TestPlugin(t *testing.T) {
-	plugin := New("")
+	plugin := New("../policy")
 	pipeline, err := getSamplePipeline("authorized-type.yml")
 	if err != nil {
 		t.Error(err)
@@ -93,5 +94,17 @@ func TestValidateInvalidPolicy(t *testing.T) {
 	if err == nil {
 		t.Error(err)
 		return
+	}
+}
+
+func TestValidateDefaultPolicy(t *testing.T) {
+	want := &plugin{
+		policyPath: "./policy",
+	}
+	got := New("")
+    if !reflect.DeepEqual(got, want) {
+		t.Error("invalid default policyPath")
+		return
+
 	}
 }


### PR DESCRIPTION
- Use `DRONE_VALIDATE_PLUGIN_SECRET` instead of `DRONE_SECRET` to keep it in sync with the var used by drone-server.
- Use the default policy path when `DRONE_POLICY_PATH` is not set.